### PR TITLE
URGENT PATCH: Fixed critical security issue in C2S_UpdateItemStack packet

### DIFF
--- a/common/src/main/java/io/github/wouink/furnish/network/C2S_UpdateItemStack.java
+++ b/common/src/main/java/io/github/wouink/furnish/network/C2S_UpdateItemStack.java
@@ -4,6 +4,7 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import io.github.wouink.furnish.Furnish;
+import io.github.wouink.furnish.item.Letter;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
 
@@ -46,8 +47,13 @@ public class C2S_UpdateItemStack extends BaseC2SMessage {
     @Override
     public void handle(NetworkManager.PacketContext context) {
         context.queue(() -> {
-            context.getPlayer().getInventory().setItem(slot, newStack);
-            context.getPlayer().getInventory().setChanged();
+            /**
+                PATCH: Fixed security vulnerability allowing arbitrary spawning of items in this packet by ensuring proper validation.
+            **/
+            if (newStack.getItem() instanceof Letter) {
+                context.getPlayer().getInventory().setItem(slot, newStack);
+                context.getPlayer().getInventory().setChanged();
+            }
         });
     }
 }


### PR DESCRIPTION
I'm running a modded Minecraft server network, and we've found a serious issue with a furnish packet that's actively being exploited by griefers. This caused a lot of damage to one of our servers - and after investigating other servers have been affected too by this same issue.

We've put together a patch that fixes the exploit - this should be pushed and merged to curseforge to prevent further damage to other servers.